### PR TITLE
Support for owning Frozen map of strings

### DIFF
--- a/src/string_map.rs
+++ b/src/string_map.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-pub(crate) struct StringMap<V> {
-    entries: HashMap<&str, V>,
+use crate::implementation_map::ImplementationMap;
+
+pub(crate) struct StringMap<'a, V> {
+    entries: HashMap<&'a str, V>,
 }
 
-impl<V> FromIterator<(&str, V)> for StringMap<V> {
-    fn from_iter<T: IntoIterator<Item = (&str, V)>>(iter: T) -> Self {
+impl<'a, V> FromIterator<(&'a str, V)> for StringMap<'a, V> {
+    fn from_iter<T: IntoIterator<Item = (&'a str, V)>>(iter: T) -> Self {
         let mut entries = HashMap::new();
         entries.extend(iter);
 
@@ -14,25 +16,25 @@ impl<V> FromIterator<(&str, V)> for StringMap<V> {
     }
 }
 
-impl<V> StringMap<V> {
-    pub fn get(&self, key: &&str) -> Option<&V> {
+impl<'a, V> ImplementationMap<&str, V> for StringMap<'a, V> {
+    fn get(&self, key: &&str) -> Option<&V> {
         self.entries.get(key)
     }
 
-    pub fn get_key_value(&self, key: &&str) -> Option<(&&str, &V)> {
+    fn get_key_value(&self, key: &&str) -> Option<(&&str, &V)> {
         self.entries.get_key_value(key)
     }
 
-    pub fn contains_key(&self, key: &&str) -> bool {
+    fn contains_key(&self, key: &&str) -> bool {
         self.entries.contains_key(key)
     }
 
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.entries.len()
     }
 }
 
-impl<V> Debug for StringMap<V>
+impl<'a, V> Debug for StringMap<'a, V>
 where
     V: Debug,
 {

--- a/src/string_map.rs
+++ b/src/string_map.rs
@@ -1,14 +1,15 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-use crate::implementation_map::ImplementationMap;
-
-pub(crate) struct StringMap<'a, V> {
-    entries: HashMap<&'a str, V>,
+pub(crate) struct StringMap<K, V> {
+    entries: HashMap<K, V>,
 }
 
-impl<'a, V> FromIterator<(&'a str, V)> for StringMap<'a, V> {
-    fn from_iter<T: IntoIterator<Item = (&'a str, V)>>(iter: T) -> Self {
+impl<K, V> FromIterator<(K, V)> for StringMap<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut entries = HashMap::new();
         entries.extend(iter);
 
@@ -16,26 +17,30 @@ impl<'a, V> FromIterator<(&'a str, V)> for StringMap<'a, V> {
     }
 }
 
-impl<'a, V> ImplementationMap<&str, V> for StringMap<'a, V> {
-    fn get(&self, key: &&str) -> Option<&V> {
+impl<K, V> StringMap<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    pub fn get(&self, key: &K) -> Option<&V> {
         self.entries.get(key)
     }
 
-    fn get_key_value(&self, key: &&str) -> Option<(&&str, &V)> {
+    pub fn get_key_value(&self, key: &K) -> Option<(&K, &V)> {
         self.entries.get_key_value(key)
     }
 
-    fn contains_key(&self, key: &&str) -> bool {
+    pub fn contains_key(&self, key: &K) -> bool {
         self.entries.contains_key(key)
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.entries.len()
     }
 }
 
-impl<'a, V> Debug for StringMap<'a, V>
+impl<'a, K, V> Debug for StringMap<K, V>
 where
+    K: Debug,
     V: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
I believe the right thing to do here is have the hash map own the strings. Conceptually feels very weird to have a frozen collection that references external strings (slices).  
Also, a hash map with a key of type `&str` would be far less restrictive in usage, I believe. Maybe I need to understand your design better... 

If you want the convenience to have lookup via anything "stringy", eg. that implements `AsRef<str>`, `&str`,  
then you can have a transparent versions of the function templates: `get()`, `get_key_value()`, `contains()`, etc.   
```
pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
where
    K: Borrow<Q>,
    Q: std::hash::Hash + Eq,
{
    self.entries.get(key)
}
``` 